### PR TITLE
Trying to figure out where to define package-wide constants.

### DIFF
--- a/shablona/__init__.py
+++ b/shablona/__init__.py
@@ -1,2 +1,6 @@
+#from .constants import *
+CONSTANT1 = 5
+CONSTANT2 = 'i am constant'
+
 from .shablona import *
 from .version import __version__

--- a/shablona/constants.py
+++ b/shablona/constants.py
@@ -1,0 +1,2 @@
+CONSTANT1 = 5
+CONSTANT2 = 'i am constant'

--- a/shablona/shablona.py
+++ b/shablona/shablona.py
@@ -4,6 +4,16 @@ from matplotlib import mlab
 from scipy.special import erf
 import scipy.optimize as opt
 
+from shablona import CONSTANT1, CONSTANT2
+
+def print_constants():
+    """
+    Function that prints the constants defined by the package.
+    This is a demonstration of the proper way to define package-wide
+    constants and then use them throughout the package."""
+    
+    print 'CONSTANT1: %s' % CONSTANT1
+    print 'CONSTANT2: %s' % CONSTANT2
 
 def transform_data(data): 
     """ 


### PR DESCRIPTION
@arokem 
Currently this isn't working and I'm hoping you either know the right way to do this or can help me figure it out. The scenario is that I have a set of constants that should be defined package-wide and they should be importable by any module (or any module within a subpackage, which doesn't really apply here yet).

It sounds like one can either define them in `__init__.py` or a new module e.g. `constants.py` if you don't want to clutter your init. But I can't get either to work. Please let me know if you have ideas to try!

Thanks
