### PR TITLE
TST: add conda cacheing to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-sudo: false
-
 language: python
+
+# sudo false implies containerized builds, so we can use cacheing
+sudo: false
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ deploy:
     tags: true
     repo: uwescience/shablona
 
-cache:
-  directories:
-    - $HOME/miniconda
-
 python:
   - 2.7
   - 3.3
@@ -52,3 +48,7 @@ before_cache:
 # clean unused packages & installed files from conda cache
 - conda clean -tp
 - xargs rm <installed_files.txt
+
+cache:
+  directories:
+    - $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,26 +11,34 @@ deploy:
     tags: true
     repo: uwescience/shablona
 
+cache:
+  directories:
+    - $HOME/miniconda
+
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+
 env:
-- CONDA="python=2.7"
-- CONDA="python=3.3"
-- CONDA="python=3.4"
-- CONDA="python=3.5"
+  - CONDA_DEPS="pip flake8 nose coverage numpy scipy matplotlib pandas" PIP_DEPS="coveralls"
 
 before_install:
-- wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
+- export MINICONDA=$HOME/miniconda
+- export PATH="$MINICONDA/bin:$PATH"
 - hash -r
+# Install conda only if necessary
+- command -v conda >/dev/null || { wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+   bash miniconda.sh -b -f -p $MINICONDA; }
 - conda config --set always_yes yes
 - conda update conda
 - conda info -a
-- conda install numpy scipy matplotlib nose coverage pandas
-- conda install flake8
-- travis_retry pip install coveralls
+- conda install python=$TRAVIS_PYTHON_VERSION $CONDA_DEPS
+- travis_retry pip install $PIP_DEPS
 
 install:
-- python setup.py install
+- python setup.py install --record installed_files.txt
 
 script:
 - nosetests -v --with-coverage --cover-package=shablona
@@ -38,3 +46,8 @@ script:
 
 after_success:
 - coveralls
+
+before_cache:
+# clean unused packages & installed files from conda cache
+- conda clean -tp
+- xargs rm <installed_files.txt


### PR DESCRIPTION
Two things:
- previously travis was doing nothing with the different Python versions. I fixed this.
- I added cacheing of the conda directory. This takes a minute or two off the build phase, depending on what packages are installed.
