### PR TITLE
TravisCI: remove index files in conda cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ after_success:
 before_cache:
 # clean unused packages & installed files from conda cache
 - conda clean --tarballs --packages --index-cache
+- rm -rf $HOME/miniconda/pkgs/cache
 - xargs rm <installed_files.txt
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ after_success:
 
 before_cache:
 # clean unused packages & installed files from conda cache
-- conda clean -tp
+- conda clean --tarballs --packages --index-cache
 - xargs rm <installed_files.txt
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ after_success:
 
 before_cache:
 # clean unused packages & installed files from conda cache
+# this makes the cache rebuilt less frequently
 - conda clean --tarballs --packages --index-cache
 - rm -rf $HOME/miniconda/pkgs/cache
 - xargs rm <installed_files.txt


### PR DESCRIPTION
I figured out what was slowing down the builds: we need to clean index files as well.
