### PR TITLE
fix path used in doc build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../shablona'))
+sys.path.insert(0, os.path.abspath('../'))
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
As currently written, the path wouldn't let you `import shablona`.
