### PR TITLE
automatic generation of api documentation through conf.py

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,16 +47,11 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 
-api:
-	@mkdir -p reference
-	$(PYTHON) tools/build_modref_templates.py shablona reference
-	@echo "Build API docs...done."
-
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf reference/*
 
-html: api
+html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,16 @@
 import sys
 import os
 
+# General information about the project.
+project = 'shablona'
+copyright = '2015, Ariel Rokem'
+
+currentdir = os.path.abspath(os.path.dirname(__file__))
+ver_file = os.path.join(currentdir, '..', project, 'version.py')
+with open(ver_file) as f:
+    exec(f.read())
+source_version = __version__
+
 currentdir = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(currentdir, 'tools'))
 import buildmodref
@@ -24,8 +34,7 @@ import buildmodref
 # (see https://github.com/rtfd/readthedocs.org/issues/1139)
 def generateapidoc(_):
     output_path = os.path.join(currentdir, 'reference')
-    module = 'shablona'
-    buildmodref.writeapi(module, output_path, True)
+    buildmodref.writeapi(project, output_path, source_version, True)
 
 def setup(app):
     app.connect('builder-inited', generateapidoc)
@@ -70,9 +79,6 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
-# General information about the project.
-project = 'shablona'
-copyright = '2015, Ariel Rokem'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -288,4 +294,3 @@ texinfo_domain_indices = False
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
-

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,18 @@
 import sys
 import os
 
+# autogenerate api documentation
+# (see https://github.com/rtfd/readthedocs.org/issues/1139)
+def generateapidoc(_):
+    cur_dir = os.path.abspath(os.path.dirname(__file__))
+    output_path = os.path.join(cur_dir, 'reference')
+    module = 'shablona'
+    sys.path.append(os.path.join(cur_dir, 'tools'))
+    import buildmodref
+    buildmodref.writeapi(module, output_path, True)
+def setup(app):
+    app.connect('builder-inited', generateapidoc)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,15 +16,17 @@
 import sys
 import os
 
+currentdir = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(currentdir, 'tools'))
+import buildmodref
+
 # autogenerate api documentation
 # (see https://github.com/rtfd/readthedocs.org/issues/1139)
 def generateapidoc(_):
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
-    output_path = os.path.join(cur_dir, 'reference')
+    output_path = os.path.join(currentdir, 'reference')
     module = 'shablona'
-    sys.path.append(os.path.join(cur_dir, 'tools'))
-    import buildmodref
     buildmodref.writeapi(module, output_path, True)
+
 def setup(app):
     app.connect('builder-inited', generateapidoc)
 

--- a/doc/tools/buildmodref.py
+++ b/doc/tools/buildmodref.py
@@ -20,17 +20,7 @@ def abort(error):
     print('*WARNING* API documentation not generated: %s' % error)
     exit()
 
-
-if __name__ == '__main__':
-    package = sys.argv[1]
-    outdir = sys.argv[2]
-    try:
-        other_defines = sys.argv[3]
-    except IndexError:
-        other_defines = True
-    else:
-        other_defines = other_defines in ('True', 'true', '1')
-
+def writeapi(package, outdir, other_defines=True):
     # Check that the package is available. If not, the API documentation is not
     # (re)generated and existing API documentation sources will be used.
 
@@ -60,9 +50,21 @@ if __name__ == '__main__':
     docwriter = ApiDocWriter(package, rst_extension='.rst',
                              other_defines=other_defines)
                              
-    docwriter.package_skip_patterns += [r'\.shablona$',
+    docwriter.package_skip_patterns += [r'\.%s$' % package,
                                         r'.*test.*$',
                                         r'\.version.*$']
     docwriter.write_api_docs(outdir)
     docwriter.write_index(outdir, 'index', relative_to=outdir)
     print('%d files written' % len(docwriter.written_modules))
+
+if __name__ == '__main__':
+    package = sys.argv[1]
+    outdir = sys.argv[2]
+    try:
+        other_defines = sys.argv[3]
+    except IndexError:
+        other_defines = True
+    else:
+        other_defines = other_defines in ('True', 'true', '1')
+
+    writeapi(package, outdir, other_defines=other_defines)

--- a/doc/tools/buildmodref.py
+++ b/doc/tools/buildmodref.py
@@ -57,6 +57,7 @@ def writeapi(package, outdir, other_defines=True):
     docwriter.write_index(outdir, 'index', relative_to=outdir)
     print('%d files written' % len(docwriter.written_modules))
 
+
 if __name__ == '__main__':
     package = sys.argv[1]
     outdir = sys.argv[2]

--- a/doc/tools/buildmodref.py
+++ b/doc/tools/buildmodref.py
@@ -6,7 +6,7 @@ from __future__ import print_function, division
 # stdlib imports
 import sys
 import re
-from os.path import join as pjoin
+import os.path
 
 # local imports
 from apigen import ApiDocWriter
@@ -38,7 +38,8 @@ def writeapi(package, outdir, other_defines=True):
 
     installed_version = V(module.__version__)
 
-    ver_file = pjoin('..', package, 'version.py')
+    currentdir = os.path.abspath(os.path.dirname(__file__))
+    ver_file = os.path.join(currentdir, '..', '..', package, 'version.py')
     with open(ver_file) as f:
         exec(f.read())
     source_version = __version__

--- a/doc/tools/buildmodref.py
+++ b/doc/tools/buildmodref.py
@@ -20,7 +20,8 @@ def abort(error):
     print('*WARNING* API documentation not generated: %s' % error)
     exit()
 
-def writeapi(package, outdir, other_defines=True):
+
+def writeapi(package, outdir, source_version, other_defines=True):
     # Check that the package is available. If not, the API documentation is not
     # (re)generated and existing API documentation sources will be used.
 
@@ -37,20 +38,12 @@ def writeapi(package, outdir, other_defines=True):
     # for older or newer versions if such versions are installed on the system.
 
     installed_version = V(module.__version__)
-
-    currentdir = os.path.abspath(os.path.dirname(__file__))
-    ver_file = os.path.join(currentdir, '..', '..', package, 'version.py')
-    with open(ver_file) as f:
-        exec(f.read())
-    source_version = __version__
-    print('***', source_version)
-
     if source_version != installed_version:
         abort("Installed version does not match source version")
 
     docwriter = ApiDocWriter(package, rst_extension='.rst',
                              other_defines=other_defines)
-                             
+
     docwriter.package_skip_patterns += [r'\.%s$' % package,
                                         r'.*test.*$',
                                         r'\.version.*$']

--- a/doc/tools/buildmodref.py
+++ b/doc/tools/buildmodref.py
@@ -6,7 +6,6 @@ from __future__ import print_function, division
 # stdlib imports
 import sys
 import re
-import os.path
 
 # local imports
 from apigen import ApiDocWriter


### PR DESCRIPTION
This PR changes conf.py to automatically generate the API reference without the need for calling the script from the Makefile. This notably also works on ReadTheDocs.
