### PR TITLE
ENH: Add python_requires metadata to package 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,6 @@ build: false
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.8"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Setuptools version should match setup.py; wheel because pip will insert it noisily
+requires = ["setuptools >= 24.2.0", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from setuptools import setup, find_packages
 PACKAGES = find_packages()
@@ -6,6 +7,13 @@ PACKAGES = find_packages()
 ver_file = os.path.join('shablona', 'version.py')
 with open(ver_file) as f:
     exec(f.read())
+
+# Give setuptools a hint to complain if it's too old a version
+# 24.2.0 added the python_requires option
+# Should match pyproject.toml
+SETUP_REQUIRES = ['setuptools >= 24.2.0']
+# This enables setuptools to install wheel on-the-fly
+SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
 
 opts = dict(name=NAME,
             maintainer=MAINTAINER,
@@ -23,6 +31,8 @@ opts = dict(name=NAME,
             packages=PACKAGES,
             package_data=PACKAGE_DATA,
             install_requires=REQUIRES,
+            python_requires=PYTHON_REQUIRES,
+            setup_requires=SETUP_REQUIRES,
             requires=REQUIRES)
 
 

--- a/shablona/version.py
+++ b/shablona/version.py
@@ -73,3 +73,4 @@ MICRO = _version_micro
 VERSION = __version__
 PACKAGE_DATA = {'shablona': [pjoin('data', '*')]}
 REQUIRES = ["numpy"]
+PYTHON_REQUIRES = ">= 3.5"


### PR DESCRIPTION
Been running across a number of packages lately that don't properly set `python_requires` as they drop compatibility for old Pythons. This adds that so that shablona-forkers play nicely as a lot of packages are finally negotiating their own ways of coping with the demise of Python 2.7.

This metadata is only supported in setuptools 24.2.0+, so I added that constraint in `setup_requires` and `pyproject.toml`, which should at least give a nice error message if they don't have new enough `setuptools` or `pip`.

Hope it's useful. After seeing #82, I also removed the AppVeyor entry for Python 2.